### PR TITLE
Refactor UI into composer and settings

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Automation Test</title></head>
+<body>
+<script src="chatgptAutomation.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- simplify UI to two tabs: composer and settings
- integrate step editors for simple, template, response, and http within composer
- overhaul logging layout and add deletion controls

## Testing
- `node --check chatgptAutomation.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa408407988333b3c3179b1d28a367