### PR TITLE
feat: refine composer workflow and placeholders

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>ChatGPT Automation Test</title>
+</head>
+<body>
+<script>
+window.GM_getValue = () => null;
+window.GM_setValue = () => {};
+window.GM_xmlhttpRequest = () => {};
+</script>
+<script src="chatgptAutomation.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rename chain workflow to Composer
- add empty-state placeholder and delete step controls
- support template-type steps and auto-link new steps

## Testing
- `node --check chatgptAutomation.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa4bc4a4f48333b86a8e85cf5c5c73