### PR TITLE
Refactor interface to composer-centric workflow

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>UI Test</title>
+</head>
+<body>
+<script src="chatgptAutomation.js"></script>
+<p>Test harness for ChatGPT Automation Pro.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace multi-tab layout with Composer and Settings only
- Add preset management in Composer and step modal, with template/JS step options and delete support
- Provide empty-state placeholder and logging/UI refinements

## Testing
- `node --check chatgptAutomation.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa4bc4a4f48333b86a8e85cf5c5c73