### PR TITLE
fix: add service worker background for chrome

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,4 @@
+// Background script placeholder for cross-browser compatibility.
+if (typeof browser === 'undefined') {
+  globalThis.browser = chrome;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "ChatGPT Automation Pro",
+  "description": "Advanced ChatGPT automation with dynamic templating",
+  "version": "2.5",
+  "manifest_version": 3,
+  "background": {
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/*", "https://chat.openai.com/*"],
+      "js": ["chatgptAutomation.js"],
+      "run_at": "document_end"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 background config with service worker
- include stub background script for cross-browser extensions

## Testing
- `node --check chatgptAutomation.js`
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec4e6dc9083338a15c9d2738bb54a