### PR TITLE
Add PayPal link in settings

### DIFF
--- a/chatgptAutomation.js
+++ b/chatgptAutomation.js
@@ -3171,6 +3171,12 @@ for (const lang in extraTranslations) {
             ${translator.instant('Controls default visibility on page load. You can still toggle from the header button.')}
           </div>
         </div>
+        <div class="form-group">
+          <label>Support:</label>
+          <div class="help-text">
+            <a href="https://www.paypal.com/paypalme/my/profile" target="_blank" rel="noopener noreferrer">Donate via PayPal</a>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add PayPal donation link to the settings tab so users can support via PayPal

## Testing
- `node --check chatgptAutomation.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2d384cd4483339ff0bae6c90bc92c