### PR TITLE
Add landing page and GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy landing page
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ChatGPT Automation Pro</title>
+  <meta name="description" content="Automate your ChatGPT workflow with an on-page assistant that sends, waits, and responds at scale. Zero copy-paste." />
+  <meta name="keywords" content="ChatGPT automation, browser automation, batch prompts, AI workflow, productivity" />
+  <style>
+    body { font-family: sans-serif; margin: 0; color: #333; background: linear-gradient(135deg,#f7f7f7,#e0f7fa); }
+    header { text-align: center; padding: 4rem 1rem; }
+    h1 { font-size: 2.5rem; margin: 0 0 1rem; }
+    p.tagline { font-size: 1.25rem; margin: 0 0 2rem; }
+    img { max-width: 90%; height: auto; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+    section { max-width: 800px; margin: 3rem auto; padding: 0 1rem; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 1rem 0; font-size: 1.1rem; }
+    footer { text-align: center; padding: 2rem 1rem; background: #fff; }
+    a.cta { display: inline-block; padding: .75rem 2rem; background: #ff6600; color: #fff; text-decoration: none; border-radius: 4px; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>ChatGPT Automation Pro</h1>
+    <p class="tagline">Batch your prompts. Capture every reply. Focus on ideas.</p>
+    <a href="https://addons.mozilla.org/en-US/firefox/addon/chatgpt-automation-pro/" class="cta">Get the Add-on</a>
+    <div><img src="image.png" alt="ChatGPT Automation Pro screenshot" /></div>
+  </header>
+  <section>
+    <h2>Why teams use it</h2>
+    <ul>
+      <li>Compose multi-step chats without the copy-paste grind</li>
+      <li>Process lists or data in one run, hands free</li>
+      <li>Review replies with built-in logs and history</li>
+      <li>Works alongside your browser, light or dark</li>
+    </ul>
+  </section>
+  <footer>
+    <p>Open-source on <a href="https://github.com/HRussellZFAC023/ChatGptAutomator">GitHub</a></p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add lightweight marketing landing page with SEO meta tags and hero call-to-action.
- Set up GitHub Pages workflow to deploy the site automatically on pushes to `main`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7522886b8833393dbd5cdf5cc67df